### PR TITLE
Changed Facebook Graph query for profile picture.

### DIFF
--- a/grabKit/grabKit/GrabKitPicker/GRKServiceGrabber+usernameAndProfilePicture/GRKFacebookGrabber+usernameAndProfilePicture.m
+++ b/grabKit/grabKit/GrabKitPicker/GRKServiceGrabber+usernameAndProfilePicture/GRKFacebookGrabber+usernameAndProfilePicture.m
@@ -66,7 +66,7 @@
 {
     
     __weak __block GRKFacebookQuery * userDataQuery = nil;
-    userDataQuery = [GRKFacebookQuery queryWithGraphPath:@"me?fields=picture.type(large),name" // we need a large picture, for retina displays...
+    userDataQuery = [GRKFacebookQuery queryWithGraphPath:@"me?fields=picture.width(88).height(88),name" // we need a large picture, for retina displays...
                                       withParams:nil
                                withHandlingBlock:^(GRKFacebookQuery *query, id result) {
 


### PR DESCRIPTION
It is best to ask for a profile picture of a specific size and let Facebook crop the image. This way the picture does not appear stretched. 

There may be other (better?) solutions though:
1. Change the UIImageView mode to Aspect Fit
2. The method `loadUsernameAndProfilePictureOfCurrentUserWithCompleteBlock:andErrorBlock:` should probably accept the needed size of the profile picture as a parameter.
