### PR TITLE
Fixed pagination bug in device picker.

### DIFF
--- a/grabKit/grabKit/GrabKitLib/helpers/NSIndexSet+pagination.h
+++ b/grabKit/grabKit/GrabKitLib/helpers/NSIndexSet+pagination.h
@@ -26,6 +26,6 @@
 
 @interface NSIndexSet (pagination)
 
-+(NSIndexSet*) indexSetForPageIndex:(NSUInteger)pageIndex withNumberOfItemsPerPage:(NSUInteger)numberOfItemsPerPage;
++(NSIndexSet*) indexSetForPageIndex:(NSUInteger)pageIndex withNumberOfItemsPerPage:(NSUInteger)numberOfItemsPerPage withNumberOfItemsOnThisPage:(NSUInteger)numberOfItemsOnThisPage;
 
 @end

--- a/grabKit/grabKit/GrabKitLib/helpers/NSIndexSet+pagination.m
+++ b/grabKit/grabKit/GrabKitLib/helpers/NSIndexSet+pagination.m
@@ -26,10 +26,10 @@
 
 @implementation NSIndexSet (pagination)
 
-+(NSIndexSet*) indexSetForPageIndex:(NSUInteger)pageIndex withNumberOfItemsPerPage:(NSUInteger)numberOfItemsPerPage;
++(NSIndexSet*) indexSetForPageIndex:(NSUInteger)pageIndex withNumberOfItemsPerPage:(NSUInteger)numberOfItemsPerPage withNumberOfItemsOnThisPage:(NSUInteger)numberOfItemsOnThisPage
 {
     // create a NSRange for the desired range (N items starting at page PN)
-    NSRange range = NSMakeRange(pageIndex*numberOfItemsPerPage, numberOfItemsPerPage);
+    NSRange range = NSMakeRange(pageIndex*numberOfItemsPerPage, numberOfItemsOnThisPage);
     
 	// create a NSIndexSet from this range
     NSIndexSet * indexSetForThisRange = [NSIndexSet indexSetWithIndexesInRange:range];

--- a/grabKit/grabKit/GrabKitLib/model/GRKAlbum.m
+++ b/grabKit/grabKit/GrabKitLib/model/GRKAlbum.m
@@ -140,24 +140,16 @@ GRKAlbumDateProperty * const kGRKAlbumDatePropertyDateUpdated = @"kGRKAlbumDateP
         return [NSArray array];
     }
     
+    NSUInteger numberOfPhotosOnCurrentPage = numberOfPhotosPerPage;
     
-    
-    
-    // create a NSIndexSet for the desired page (N photos starting at page PN)
-    NSIndexSet * indexSetForThisPage = [NSIndexSet indexSetForPageIndex:pageIndex withNumberOfItemsPerPage:numberOfPhotosPerPage];
-    
-    
-    // If the last photo of the desired page is further than the last photo, 
-    // we have to change the indexSet to fit : first photo of the page -> last photo 
-    // (because we use the method [NSArray objectsAtIndexes], which throws NSException for out of bounds indexes...)
     if ( pageIndex*numberOfPhotosPerPage + numberOfPhotosPerPage > [_photosIds count] ){
     
-        NSUInteger correctedNumberOfPhotosPerPage = [_photosIds count] - pageIndex*numberOfPhotosPerPage;
-        
-        indexSetForThisPage = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(pageIndex*numberOfPhotosPerPage, correctedNumberOfPhotosPerPage)];
+        numberOfPhotosOnCurrentPage = [_photosIds count] - pageIndex*numberOfPhotosPerPage;
         
     }
     
+    // create a NSIndexSet for the desired page (N photos starting at page PN)
+    NSIndexSet * indexSetForThisPage = [NSIndexSet indexSetForPageIndex:pageIndex withNumberOfItemsPerPage:numberOfPhotosPerPage withNumberOfItemsOnThisPage:numberOfPhotosOnCurrentPage];
 	
     // Ask for the photos ids at these indexes
 	NSMutableArray * keysForThisPage = nil;

--- a/grabKit/grabKit/GrabKitLib/serviceGrabbers/deviceGrabber/GRKDeviceGrabber.m
+++ b/grabKit/grabKit/GrabKitLib/serviceGrabbers/deviceGrabber/GRKDeviceGrabber.m
@@ -60,7 +60,7 @@ static NSString *kGRKServiceNameDevice = @"device";
         cancelAllCompleteBlock = nil;
         
         _requiresConnection = NO;
-    }     
+    }
     
     return self;
 }
@@ -225,12 +225,12 @@ Then : we have to fetch from "(page index) * (number of photo per page)" to "ran
  This is what the finalN var is made for, avoiding that way the NSRangeException.
  */
     
-    NSUInteger finalNumberOfPhotosPerPage = numberOfPhotosPerPage;
+    NSUInteger numberOfPhotosOnCurrentPage = numberOfPhotosPerPage;
     if ( pageIndex*numberOfPhotosPerPage + numberOfPhotosPerPage > album.count ){
-        finalNumberOfPhotosPerPage = MAX(0,album.count - pageIndex*numberOfPhotosPerPage);
+        numberOfPhotosOnCurrentPage = MAX(0,album.count - pageIndex*numberOfPhotosPerPage);
     }
 
-    NSIndexSet * indexSetAtThisPageIndex = [NSIndexSet indexSetForPageIndex:pageIndex withNumberOfItemsPerPage:finalNumberOfPhotosPerPage];
+    NSIndexSet * indexSetAtThisPageIndex = [NSIndexSet indexSetForPageIndex:pageIndex withNumberOfItemsPerPage:numberOfPhotosPerPage withNumberOfItemsOnThisPage:numberOfPhotosOnCurrentPage];
     
     [self incrementQueriesCount];
     cancelAllFlag = NO;


### PR DESCRIPTION
Some CaseCollage users were seeing that the newest images on their camera roll were not being shown. Fixed this by modifying the way page index sets are computed.
